### PR TITLE
Pin functionality and simplified UI for Geothermal Plant activity

### DIFF
--- a/css/pins-layer.less
+++ b/css/pins-layer.less
@@ -12,6 +12,9 @@
   &.fixed-position {
     pointer-events: none;
   }
+  &.colorful-pin {
+    color: #ffe839;
+  }
   .map-pin-content {
     font-size: 16px;
     line-height: 18px;

--- a/css/pins-layer.less
+++ b/css/pins-layer.less
@@ -1,6 +1,9 @@
 .map-pin-icon  {
   color: #fafafa;
+  -webkit-text-stroke-width: 0.5px;
+  -webkit-text-stroke-color: rgb(46, 46, 46);
   text-shadow: 1px 1px 3px #000;
+  font-weight: bold;
   width: 200px !important;
   height: 100px !important;
   margin-left: -100px !important;

--- a/css/pins-layer.less
+++ b/css/pins-layer.less
@@ -1,5 +1,4 @@
 .map-pin-icon  {
-  pointer-events: none;
   color: #fafafa;
   text-shadow: 1px 1px 3px #000;
   width: 200px !important;
@@ -7,7 +6,9 @@
   margin-left: -100px !important;
   margin-top: -100px !important;
   text-align: center;
-
+  &.fixed-position {
+    pointer-events: none;
+  }
   .map-pin-content {
     font-size: 16px;
     line-height: 18px;

--- a/css/simplified-controls.less
+++ b/css/simplified-controls.less
@@ -1,0 +1,8 @@
+.simplified-controls{
+  position: fixed;
+  bottom: 20px;
+  left: 45%;
+  .modal-style{
+    width: 200px;
+  }
+}

--- a/css/simplified-controls.less
+++ b/css/simplified-controls.less
@@ -1,7 +1,7 @@
 .simplified-controls{
   position: fixed;
   bottom: 20px;
-  left: 45%;
+  left: 20px;
   .modal-style{
     width: 200px;
   }

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -21,6 +21,7 @@ export const SET_EARTHQUAKES_VISIBLE = 'SET_EARTHQUAKES_VISIBLE'
 export const SET_VOLCANOES_VISIBLE = 'SET_VOLCANOES_VISIBLE'
 export const SET_PLATE_MOVEMENT_VISIBLE = 'SET_PLATE_MOVEMENT_VISIBLE'
 export const SET_PLATE_ARROWS_VISIBLE = 'SET_PLATE_ARROWS_VISIBLE'
+export const SET_PIN = 'SET_PIN'
 
 const api = new EarthquakeDataAPI()
 
@@ -171,6 +172,14 @@ export function setAnimationEnabled (value) {
   return {
     type: SET_ANIMATION_ENABLED,
     value
+  }
+}
+export function setPin (index, latLng, label) {
+  return {
+    type: SET_PIN,
+    index,
+    latLng,
+    label
   }
 }
 

--- a/js/actions/index.js
+++ b/js/actions/index.js
@@ -22,6 +22,7 @@ export const SET_VOLCANOES_VISIBLE = 'SET_VOLCANOES_VISIBLE'
 export const SET_PLATE_MOVEMENT_VISIBLE = 'SET_PLATE_MOVEMENT_VISIBLE'
 export const SET_PLATE_ARROWS_VISIBLE = 'SET_PLATE_ARROWS_VISIBLE'
 export const SET_PIN = 'SET_PIN'
+export const UPDATE_PIN = 'UPDATE_PIN'
 
 const api = new EarthquakeDataAPI()
 
@@ -180,6 +181,15 @@ export function setPin (index, latLng, label) {
     index,
     latLng,
     label
+  }
+}
+
+export function updatePin (index, latLng, marker) {
+  return {
+    type: UPDATE_PIN,
+    index,
+    latLng,
+    marker
   }
 }
 

--- a/js/components/pins-layer.js
+++ b/js/components/pins-layer.js
@@ -6,7 +6,7 @@ import config from '../config'
 import '../../css/pins-layer.less'
 
 const getPinIcon = label => L.divIcon({
-  className: `map-pin-icon ${!config.allowPinDrag && 'fixed-position'}`,
+  className: `map-pin-icon ${!config.allowPinDrag && 'fixed-position'} ${config.clickToMoveSinglePin && 'colorful-pin'}`,
   html: `<div class="map-pin-content">${label}<div class='pin fa fa-map-pin' /></div>`
 })
 

--- a/js/components/pins-layer.js
+++ b/js/components/pins-layer.js
@@ -6,7 +6,7 @@ import config from '../config'
 import '../../css/pins-layer.less'
 
 const getPinIcon = label => L.divIcon({
-  className: `map-pin-icon ${!config.allowPinDrag && "fixed-position"}`,
+  className: `map-pin-icon ${!config.allowPinDrag && 'fixed-position'}`,
   html: `<div class="map-pin-content">${label}<div class='pin fa fa-map-pin' /></div>`
 })
 

--- a/js/components/pins-layer.js
+++ b/js/components/pins-layer.js
@@ -6,7 +6,7 @@ import config from '../config'
 import '../../css/pins-layer.less'
 
 const getPinIcon = label => L.divIcon({
-  className: 'map-pin-icon',
+  className: `map-pin-icon ${!config.allowPinDrag && "fixed-position"}`,
   html: `<div class="map-pin-content">${label}<div class='pin fa fa-map-pin' /></div>`
 })
 
@@ -17,7 +17,11 @@ export default withLeaflet(class PinsLayer extends WrappingMapLayer {
 
   getElement (data, idx) {
     const { lat, lng, label } = data
-    const el = new L.Marker([lat, lng], { icon: getPinIcon(label) })
+    const el = new L.Marker([lat, lng], {
+      icon: getPinIcon(label),
+      draggable: config.allowPinDrag,
+      bubblingMouseEvents: !config.allowPinDrag
+    })
     el.lat = lat
     el.lng = lng
     return el

--- a/js/components/pins-layer.js
+++ b/js/components/pins-layer.js
@@ -10,20 +10,30 @@ const getPinIcon = label => L.divIcon({
   html: `<div class="map-pin-content">${label}<div class='pin fa fa-map-pin' /></div>`
 })
 
+const allPins = []
+
 export default withLeaflet(class PinsLayer extends WrappingMapLayer {
   getData () {
-    return config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2] }))
+    return this.props.pins.toJS() // config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2] }))
   }
 
   getElement (data, idx) {
     const { lat, lng, label } = data
-    const el = new L.Marker([lat, lng], {
-      icon: getPinIcon(label),
-      draggable: config.allowPinDrag,
-      bubblingMouseEvents: !config.allowPinDrag
-    })
-    el.lat = lat
-    el.lng = lng
-    return el
+    if (idx > allPins.length - 1) {
+      const el = new L.Marker([lat, lng], {
+        icon: getPinIcon(label),
+        draggable: config.allowPinDrag,
+        bubblingMouseEvents: !config.allowPinDrag
+      })
+      el.lat = lat
+      el.lng = lng
+      allPins.push(el)
+      return el
+    } else {
+      const existingPin = allPins[idx]
+      const newLatLng = new L.LatLng(lat, lng)
+      existingPin.setLatLng(newLatLng)
+      return existingPin
+    }
   }
 })

--- a/js/components/pins-layer.js
+++ b/js/components/pins-layer.js
@@ -10,16 +10,17 @@ const getPinIcon = label => L.divIcon({
   html: `<div class="map-pin-content">${label}<div class='pin fa fa-map-pin' /></div>`
 })
 
-const allPins = []
-
 export default withLeaflet(class PinsLayer extends WrappingMapLayer {
   getData () {
     return this.props.pins.toJS() // config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2] }))
   }
 
   getElement (data, idx) {
+    const { pins } = this.props
+    const pinList = pins.toJS()
+    const existingPin = pinList[idx] ? pinList[idx].marker : undefined
     const { lat, lng, label } = data
-    if (idx > allPins.length - 1) {
+    if (!existingPin) {
       const el = new L.Marker([lat, lng], {
         icon: getPinIcon(label),
         draggable: config.allowPinDrag,
@@ -27,12 +28,12 @@ export default withLeaflet(class PinsLayer extends WrappingMapLayer {
       })
       el.lat = lat
       el.lng = lng
-      allPins.push(el)
+      this.props.onPinUpdated(idx, el, { lat, lng })
       return el
     } else {
-      const existingPin = allPins[idx]
       const newLatLng = new L.LatLng(lat, lng)
       existingPin.setLatLng(newLatLng)
+      this.props.onPinUpdated(idx, existingPin, { lat, lng })
       return existingPin
     }
   }

--- a/js/components/seismic-eruptions-map.js
+++ b/js/components/seismic-eruptions-map.js
@@ -100,8 +100,7 @@ export default class SeismicEruptionsMap extends PureComponent {
     setMapStatus(this.mapRegion, this.mapZoom)
 
     this.map.on('click', (e) => {
-      // TOOD: remove, it can be useful to tweak position of plate arrows.
-      console.log('lat:', e.latlng.lat, 'lng:', e.latlng.lng)
+      this.handleMapClick(e)
     })
     if (!config.sizeToFitBounds) {
       // if we are not using bounds, and instead using a center point, force a refresh of the viewport to
@@ -189,6 +188,12 @@ export default class SeismicEruptionsMap extends PureComponent {
     this.setState({ selectedVolcano: null })
   }
 
+  handleMapClick (e) {
+    console.log('lat:', e.latlng.lat, 'lng:', e.latlng.lng)
+    if (config.clickToMoveSinglePin) {
+      this.props.setPin(0, e.latlng, config.defaultPinLabel)
+    }
+  }
   calculateScale () {
     // const bounds = this.map.getBounds()
     // const distWidthM = bounds.getSouthWest().distanceTo(bounds.getSouthEast())
@@ -211,7 +216,7 @@ export default class SeismicEruptionsMap extends PureComponent {
   }
 
   render () {
-    const { mode, earthquakes, volcanoes, layers, crossSectionPoints, mapStatus, setCrossSectionPoint } = this.props
+    const { mode, earthquakes, volcanoes, layers, crossSectionPoints, mapStatus, setCrossSectionPoint, pins } = this.props
     const { selectedEarthquake, selectedVolcano } = this.state
     const baseLayer = this.baseLayer
     let url = baseLayer.url
@@ -229,6 +234,8 @@ export default class SeismicEruptionsMap extends PureComponent {
     const center = config.sizeToFitBounds ? undefined : INITIAL_CENTER
     const zoom = this.map ? this.mapZoom : config.centeredInitialZoom
 
+    const showZoomControls = config.minZoom !== config.maxZoom
+
     return (
       <div className={`seismic-eruptions-map mode-${mode}`}>
         <Map ref='map' className='map'
@@ -241,6 +248,7 @@ export default class SeismicEruptionsMap extends PureComponent {
           doubleClickZoom={allowFreeMouseZoom}
           scrollWheelZoom={allowFreeMouseZoom}
           onzoomend={this.handleZoom}
+          zoomControl={showZoomControls}
         >
           {/* #key attribute is very important here. #subdomains is not a dynamic property, so we can't reuse the same */}
           {/* component instance when we switch between maps with subdomains and without. */}
@@ -250,7 +258,7 @@ export default class SeismicEruptionsMap extends PureComponent {
           {layers.get('plateNames') && <LabelsLayer mapRegion={mapStatus.get('region')} labels={plateNames} />}
           {layers.get('plateArrows') && <PlateArrowsLayer mapRegion={mapStatus.get('region')} />}
           {layers.get('plateMovement') && <PlateMovementLayer />}
-          {config.pins && config.pins.length > 0 && <PinsLayer mapRegion={mapStatus.get('region')} />}
+          {pins && <PinsLayer mapRegion={mapStatus.get('region')} pins={pins} />}
           {mode !== '3d' &&
             /* Performance optimization. Update of this component is expensive. Remove it when the map is invisible. */
             <SpritesLayer earthquakes={earthquakes} volcanoes={volcanoes}
@@ -265,11 +273,11 @@ export default class SeismicEruptionsMap extends PureComponent {
           {mode === 'cross-section' &&
             <CrossSectionDrawLayer crossSectionPoints={crossSectionPoints} setCrossSectionPoint={setCrossSectionPoint} />
           }
-          {!config.showUserInterface &&
+          {!config.showUserInterface && showZoomControls &&
             <ScaleControl position={'topleft'} />
           }
         </Map>
-        {!config.showUserInterface &&
+        {!config.showUserInterface && showZoomControls &&
           <div className='scale-markers'>
             <div>
               <div>{`Zoom level: ${zoom}`}</div>

--- a/js/components/seismic-eruptions-map.js
+++ b/js/components/seismic-eruptions-map.js
@@ -53,6 +53,7 @@ export default class SeismicEruptionsMap extends PureComponent {
     this.handleMapViewportChanged = this.handleMapViewportChanged.bind(this)
     this.handleInitialBoundsSetup = this.handleInitialBoundsSetup.bind(this)
     this.handleZoom = this.handleZoom.bind(this)
+    this.handlePinUpdated = this.handlePinUpdated.bind(this)
   }
 
   get map () {
@@ -190,10 +191,26 @@ export default class SeismicEruptionsMap extends PureComponent {
 
   handleMapClick (e) {
     console.log('lat:', e.latlng.lat, 'lng:', e.latlng.lng)
+
+    const { pins } = this.props
+    // Note that this doesn't yet work if we need to move more than one pin. In future, we could
+    // extend to enable click-to-add more pins
+    const maxPins = 1
     if (config.clickToMoveSinglePin) {
-      this.props.setPin(0, e.latlng, config.defaultPinLabel)
+      const pinList = pins.toJS()
+      if (pinList.length < maxPins) {
+        this.props.setPin(pinList.length, e.latlng, config.defaultPinLabel)
+      } else {
+        // update the position of the last-placed pin
+        this.props.updatePin(pinList.length - 1, e.latlng)
+      }
     }
   }
+  handlePinUpdated (idx, markerElement, latLng) {
+    // update state with marker from Leaflet
+    this.props.updatePin(idx, latLng, markerElement)
+  }
+
   calculateScale () {
     // const bounds = this.map.getBounds()
     // const distWidthM = bounds.getSouthWest().distanceTo(bounds.getSouthEast())
@@ -258,7 +275,7 @@ export default class SeismicEruptionsMap extends PureComponent {
           {layers.get('plateNames') && <LabelsLayer mapRegion={mapStatus.get('region')} labels={plateNames} />}
           {layers.get('plateArrows') && <PlateArrowsLayer mapRegion={mapStatus.get('region')} />}
           {layers.get('plateMovement') && <PlateMovementLayer />}
-          {pins && <PinsLayer mapRegion={mapStatus.get('region')} pins={pins} />}
+          {pins && <PinsLayer mapRegion={mapStatus.get('region')} pins={pins} onPinUpdated={this.handlePinUpdated} />}
           {mode !== '3d' &&
             /* Performance optimization. Update of this component is expensive. Remove it when the map is invisible. */
             <SpritesLayer earthquakes={earthquakes} volcanoes={volcanoes}

--- a/js/config.js
+++ b/js/config.js
@@ -68,6 +68,7 @@ const DEFAULT_CONFIG = {
   detailedPlateMovementVisible: false,
   // Remove bottom bar and other UI elements from the view by setting to false
   showUserInterface: true,
+  simplifiedUI: false,
   // allow dragging / panning the map
   allowDrag: true,
   // min/max zoom levels. If set to -1 this has no effect

--- a/js/config.js
+++ b/js/config.js
@@ -7,6 +7,8 @@ const DEFAULT_CONFIG = {
   // pins=[[0, 0, "test pin"], [20, 50, "another pin"]]
   pins: [],
   allowPinDrag: false,
+  clickToMoveSinglePin: false,
+  defaultPinLabel: '',
   // Initial map region.
   minLat: -60,
   minLng: -120,

--- a/js/config.js
+++ b/js/config.js
@@ -6,6 +6,7 @@ const DEFAULT_CONFIG = {
   // Authorable pins. A single pin is defined by array: [<lat>, <lng>, <label>]. E.g.:
   // pins=[[0, 0, "test pin"], [20, 50, "another pin"]]
   pins: [],
+  allowPinDrag: false,
   // Initial map region.
   minLat: -60,
   minLng: -120,

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -62,9 +62,9 @@ class App extends PureComponent {
 
   renderApp () {
     const { dataFetching, earthquakes, volcanoes, layers, crossSectionPoints, mapStatus, setMapStatus, updateEarthquakesData,
-      mark2DViewModified, mark3DViewModified, mode, setCrossSectionPoint, changedViews, pins, setPin } = this.props
+      mark2DViewModified, mark3DViewModified, mode, setCrossSectionPoint, changedViews, pins, setPin, updatePin } = this.props
     const showUI = config.showUserInterface
-    const simplifiedUI = config.simplifiedUI
+    const simplifiedUI = !showUI && config.simplifiedUI
     return (
       <div>
         {dataFetching && <LoadingIcon />}
@@ -78,7 +78,7 @@ class App extends PureComponent {
             mode={mode} layers={layers} crossSectionPoints={crossSectionPoints} mapStatus={mapStatus} mapModified={changedViews.has('2d')}
             setMapStatus={setMapStatus} setCrossSectionPoint={setCrossSectionPoint} mark2DViewModified={mark2DViewModified}
             updateEarthquakesData={updateEarthquakesData}
-            pins={pins} setPin={setPin} />
+            pins={pins} setPin={setPin} updatePin={updatePin} />
           {mode === '3d' &&
             <CrossSection3D ref='view3d' earthquakes={earthquakes} volcanoes={volcanoes} crossSectionPoints={crossSectionPoints}
               mapType={layers.get('base')} latLngToPoint={this.latLngToPoint}

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -64,7 +64,7 @@ class App extends PureComponent {
     const { dataFetching, earthquakes, volcanoes, layers, crossSectionPoints, mapStatus, setMapStatus, updateEarthquakesData,
       mark2DViewModified, mark3DViewModified, mode, setCrossSectionPoint, changedViews, pins, setPin } = this.props
     const showUI = config.showUserInterface
-    const pinUI = config.clickToMoveSinglePin
+    const simplifiedUI = config.simplifiedUI
     return (
       <div>
         {dataFetching && <LoadingIcon />}
@@ -93,7 +93,7 @@ class App extends PureComponent {
             <BottomControls />
           </div>
         }
-        {pinUI &&
+        {simplifiedUI &&
           <SimplifiedControls />
         }
       </div>

--- a/js/containers/app.js
+++ b/js/containers/app.js
@@ -8,6 +8,7 @@ import SeismicEruptionsMap from '../components/seismic-eruptions-map'
 import CrossSection3D from '../components/cross-section-3d'
 import LoadingIcon from '../components/loading-icon'
 import SplashScreen from '../components/splash-screen'
+import SimplifiedControls from './simplified-controls'
 import { enableShutterbug, disableShutterbug } from '../shutterbug-support'
 import { getVisibleEarthquakes, getVisibleVolcanoes } from '../selectors'
 import config from '../config'
@@ -61,8 +62,9 @@ class App extends PureComponent {
 
   renderApp () {
     const { dataFetching, earthquakes, volcanoes, layers, crossSectionPoints, mapStatus, setMapStatus, updateEarthquakesData,
-      mark2DViewModified, mark3DViewModified, mode, setCrossSectionPoint, changedViews } = this.props
+      mark2DViewModified, mark3DViewModified, mode, setCrossSectionPoint, changedViews, pins, setPin } = this.props
     const showUI = config.showUserInterface
+    const pinUI = config.clickToMoveSinglePin
     return (
       <div>
         {dataFetching && <LoadingIcon />}
@@ -75,7 +77,8 @@ class App extends PureComponent {
           <SeismicEruptionsMap ref='map' earthquakes={earthquakes} volcanoes={volcanoes}
             mode={mode} layers={layers} crossSectionPoints={crossSectionPoints} mapStatus={mapStatus} mapModified={changedViews.has('2d')}
             setMapStatus={setMapStatus} setCrossSectionPoint={setCrossSectionPoint} mark2DViewModified={mark2DViewModified}
-            updateEarthquakesData={updateEarthquakesData} />
+            updateEarthquakesData={updateEarthquakesData}
+            pins={pins} setPin={setPin} />
           {mode === '3d' &&
             <CrossSection3D ref='view3d' earthquakes={earthquakes} volcanoes={volcanoes} crossSectionPoints={crossSectionPoints}
               mapType={layers.get('base')} latLngToPoint={this.latLngToPoint}
@@ -89,6 +92,9 @@ class App extends PureComponent {
           <div className='bottom-controls-container'>
             <BottomControls />
           </div>
+        }
+        {pinUI &&
+          <SimplifiedControls />
         }
       </div>
     )
@@ -116,7 +122,8 @@ function mapStateToProps (state) {
     earthquakes: getVisibleEarthquakes(state),
     volcanoes: getVisibleVolcanoes(state),
     crossSectionPoints: state.get('crossSectionPoints'),
-    mapStatus: state.get('mapStatus')
+    mapStatus: state.get('mapStatus'),
+    pins: state.get('pins')
   }
 }
 

--- a/js/containers/map-controls.js
+++ b/js/containers/map-controls.js
@@ -37,10 +37,10 @@ class MapControls extends PureComponent {
     log('MapLayerChanged', { layer })
   }
 
-  getMapTypes() {
+  getMapTypes () {
     const { mapTypeFilters } = this.props
     if (mapTypeFilters) {
-      const maps = [];
+      const maps = []
       layerInfo.map((m, idx) => {
         if (mapTypeFilters.indexOf(m.type) > -1) {
           const name = m.name.indexOf(' ') > -1 ? m.name.substring(0, m.name.indexOf(' ')) : m.name

--- a/js/containers/map-controls.js
+++ b/js/containers/map-controls.js
@@ -37,6 +37,26 @@ class MapControls extends PureComponent {
     log('MapLayerChanged', { layer })
   }
 
+  getMapTypes() {
+    const { mapTypeFilters } = this.props
+    if (mapTypeFilters) {
+      const maps = [];
+      layerInfo.map((m, idx) => {
+        if (mapTypeFilters.indexOf(m.type) > -1) {
+          const name = m.name.indexOf(' ') > -1 ? m.name.substring(0, m.name.indexOf(' ')) : m.name
+          maps.push(<FormControlLabel key={idx} value={m.type} control={<Radio />} label={name}
+          />)
+        }
+      })
+      return maps
+    } else {
+      return layerInfo.map((m, idx) =>
+        <FormControlLabel key={idx} value={m.type} control={<Radio />} label={m.name}
+        />
+      )
+    }
+  }
+
   render () {
     const { layers } = this.props
     const { opened } = this.state
@@ -49,12 +69,7 @@ class MapControls extends PureComponent {
             <div className='title'>Maps:</div>
             <div title='Change the map rendering style'>
               <RadioGroup value={layers.get('base')} onChange={this.handleBaseLayerChange}>
-                {
-                  layerInfo.map((m, idx) =>
-                    <FormControlLabel key={idx} value={m.type} control={<Radio />} label={m.name}
-                    />
-                  )
-                }
+                {this.getMapTypes()}
               </RadioGroup>
             </div>
           </div>

--- a/js/containers/simplified-controls.js
+++ b/js/containers/simplified-controls.js
@@ -29,7 +29,7 @@ class SimplifiedControls extends PureComponent {
   render () {
     return (
       <div className='simplified-controls'>
-        <MapControls />
+        <MapControls mapTypeFilters={['street', 'satellite']} />
         <LayerControls />
       </div>
     )

--- a/js/containers/simplified-controls.js
+++ b/js/containers/simplified-controls.js
@@ -11,9 +11,6 @@ import '../../css/simplified-controls.less'
 class SimplifiedControls extends PureComponent {
   constructor (props) {
     super(props)
-    this.state = {
-    }
-
     this.handleBaseLayerChange = this.handleBaseLayerChange.bind(this)
   }
   get mapLayerOptions () {

--- a/js/containers/simplified-controls.js
+++ b/js/containers/simplified-controls.js
@@ -1,0 +1,48 @@
+import React, { PureComponent } from 'react'
+import { connect } from 'react-redux'
+import LayerControls from './layer-controls'
+import MapControls from './map-controls'
+import { layerInfo } from '../map-layer-tiles'
+import log from '../logger'
+import * as actions from '../actions'
+
+import '../../css/simplified-controls.less'
+
+class SimplifiedControls extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {
+    }
+
+    this.handleBaseLayerChange = this.handleBaseLayerChange.bind(this)
+  }
+  get mapLayerOptions () {
+    return layerInfo.map((m, idx) => <option key={idx} value={m.type}>{m.name}</option>)
+  }
+
+  handleBaseLayerChange (event) {
+    const { setBaseLayer } = this.props
+    const layer = event.target.value
+    setBaseLayer(layer)
+    log('MapLayerChanged', { layer })
+  }
+  render () {
+    return (
+      <div className='simplified-controls'>
+        <MapControls />
+        <LayerControls />
+      </div>
+    )
+  }
+}
+
+function mapStateToProps (state) {
+  return {
+    filters: state.get('filters'),
+    layers: state.get('layers'),
+    mode: state.get('mode'),
+    pins: state.get('pins')
+  }
+}
+
+export default connect(mapStateToProps, actions)(SimplifiedControls)

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -20,7 +20,8 @@ import {
   SET_VOLCANOES_VISIBLE,
   SET_PLATE_MOVEMENT_VISIBLE,
   SET_PLATE_ARROWS_VISIBLE,
-  SET_PIN
+  SET_PIN,
+  UPDATE_PIN
 } from '../actions'
 import config from '../config'
 
@@ -140,14 +141,28 @@ function layers (state = INITIAL_LAYERS, action) {
       return state
   }
 }
-const pinList = config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2] }))
-console.log(pinList)
+const pinList = config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2], marker: undefined }))
+
 const INITIAL_PINS = List(pinList)
 
 function pins (state = INITIAL_PINS, action) {
   switch (action.type) {
     case SET_PIN:
-      return state.set(action.index, { lat: action.latLng.lat, lng: action.latLng.lng, label: action.label })
+      return state.set(action.index, { lat: action.latLng.lat, lng: action.latLng.lng, label: action.label, marker: undefined })
+    case UPDATE_PIN:
+      const updatedPinList = state.map((item, index) => {
+        if (index !== action.index) {
+          return item
+        }
+        // else this pin was moved / marker reference updated. Preserve label
+        if (action.marker) {
+          return { lat: action.latLng.lat, lng: action.latLng.lng, label: item.label, marker: action.marker }
+        } else {
+          // use existing marker reference
+          return { lat: action.latLng.lat, lng: action.latLng.lng, label: item.label, marker: item.marker }
+        }
+      })
+      return updatedPinList
     default:
       return state
   }

--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -19,7 +19,8 @@ import {
   SET_EARTHQUAKES_VISIBLE,
   SET_VOLCANOES_VISIBLE,
   SET_PLATE_MOVEMENT_VISIBLE,
-  SET_PLATE_ARROWS_VISIBLE
+  SET_PLATE_ARROWS_VISIBLE,
+  SET_PIN
 } from '../actions'
 import config from '../config'
 
@@ -139,6 +140,18 @@ function layers (state = INITIAL_LAYERS, action) {
       return state
   }
 }
+const pinList = config.pins.map(data => ({ lat: data[0], lng: data[1], label: data[2] }))
+console.log(pinList)
+const INITIAL_PINS = List(pinList)
+
+function pins (state = INITIAL_PINS, action) {
+  switch (action.type) {
+    case SET_PIN:
+      return state.set(action.index, { lat: action.latLng.lat, lng: action.latLng.lng, label: action.label })
+    default:
+      return state
+  }
+}
 
 function animationEnabled (state = false, action) {
   switch (action.type) {
@@ -190,4 +203,5 @@ export default function reducer (state = Map(), action) {
     .set('filters', filters(state.get('filters'), action))
     .set('changedViews', changedViews(state.get('changedViews'), action))
     .set('downloadStatus', downloadStatus(state.get('downloadStatus'), action))
+    .set('pins', pins(state.get('pins'), action))
 }


### PR DESCRIPTION
This PR aims to leave all the current functionality of pins intact, but adds the option to click-move (or click-add) a pin to the map with the specified text.

This is for the NGSA activity to place a geothermal plant in Iceland. 
[#171614583]

Example URL: https://seismic-explorer.concord.org/branch/geothermal-plant/index.html?allowPinDrag&clickToMoveSinglePin&defaultPinLabel=Geothermal%20Plant&centerLat=65&centerLng=-18&centeredInitialZoom=7&sizeToFitBounds=false&mapStyle=street&crossSection=false&plateBoundariesAvailable=false&plateNamesAvailable=false&continentOceanNamesAvailable=false&earthquakesDisplayAllOnStart&volcanoesVisible&plateMovementAvailable=false&showUserInterface=false&allowDrag=false&zoomMax=7&zoomMin=7